### PR TITLE
67-展覧会日程のスタイリング修正

### DIFF
--- a/app/[locale]/features/Teaser.tsx
+++ b/app/[locale]/features/Teaser.tsx
@@ -142,25 +142,60 @@ export default function Teaser() {
         >
           <div className="flex flex-col gap-6 pt-4">
             <div>
-              <div className="flex items-start gap-3 md:gap-5 mb-2">
-                <div className="flex flex-col items-center">
-                  <span className="text-5xl md:text-7xl font-light tracking-tighter leading-none">
-                    {t("teaser.dates.start")}
-                  </span>
-                  <span className="text-3xl md:text-4xl font-normal mt-1 inline-block scale-y-80 origin-top tracking-widest">
-                    {t("teaser.dates.startDay")}
-                  </span>
+              <div className="flex items-start gap-2 md:gap-3 mb-2">
+                {/* Start Date */}
+                <div className="flex flex-col">
+                  <div className="flex items-center justify-center">
+                    <span className="text-3xl md:text-4xl font-light tracking-tighter leading-none mb-2 md:mb-3 -mr-0.5 md:-mr-1">
+                      {t("teaser.dates.start").split("/")[0]}
+                    </span>
+                    <span className="block w-px h-10 md:h-12 bg-current transform rotate-30 mx-2 md:mx-3" />
+                    <span className="text-3xl md:text-4xl font-light tracking-tighter leading-none mt-2 md:mt-3 -ml-0.5 md:-ml-1">
+                      {t("teaser.dates.start").split("/")[1]}
+                    </span>
+                  </div>
+                  <div className="flex justify-between w-full mt-1 px-0.5">
+                    {t("teaser.dates.startDay")
+                      .split("")
+                      .map((char, i) => (
+                        <span
+                          key={i}
+                          className="text-xl md:text-2xl font-normal leading-none scale-y-80 origin-top"
+                        >
+                          {char}
+                        </span>
+                      ))}
+                  </div>
                 </div>
-                <span className="text-5xl md:text-7xl font-light tracking-tighter leading-none">
-                  -
-                </span>
-                <div className="flex flex-col items-center">
-                  <span className="text-5xl md:text-7xl font-light tracking-tighter leading-none">
-                    {t("teaser.dates.end")}
-                  </span>
-                  <span className="text-3xl md:text-4xl font-normal mt-1 inline-block scale-y-80 origin-top tracking-widest">
-                    {t("teaser.dates.endDay")}
-                  </span>
+
+                {/* Separator */}
+                <div className="h-10 md:h-12 flex items-end">
+                  <span className="block w-2 mb-2 md:mb-2.5 md:w-2.5 h-px bg-current" />
+                </div>
+
+                {/* End Date */}
+                <div className="flex flex-col">
+                  <div className="flex items-center justify-center">
+                    <span className="text-3xl md:text-4xl font-light tracking-tighter leading-none mb-2 md:mb-3 -mr-0.5 md:-mr-1">
+                      {t("teaser.dates.end").split("/")[0]}
+                    </span>
+                    <span className="block w-px h-10 md:h-12 bg-current transform rotate-30 mx-2 md:mx-3" />
+                    <span className="text-3xl md:text-4xl font-light tracking-tighter leading-none mt-2 md:mt-3 -ml-0.5 md:-ml-1">
+                      {t("teaser.dates.end").split("/")[1]}
+                    </span>
+                  </div>
+                  <div className="flex justify-between w-full mt-1 px-0.5">
+                    {t("teaser.dates.endDay")
+                      .split("")
+                      .map((char, i) => (
+                        <span
+                          key={i}
+                          className="text-xl md:text-2xl font-normal leading-none scale-y-80 origin-top"
+                        >
+                          {char}
+                        </span>
+                      ))}
+                  </div>
                 </div>
               </div>
               <p className="text-sm font-medium">{t("teaser.admission")}</p>


### PR DESCRIPTION
Refactor Teaser component layout for improved date display
- Enhanced the structure of the start and end date sections for better readability.
- Introduced a separator between the start and end dates.
- Updated styling for date elements to ensure consistent presentation across different screen sizes.

<img width="516" height="467" alt="image" src="https://github.com/user-attachments/assets/08875f1b-c4eb-4e83-9e7e-a1b8e6db87b0" />

<img width="281" height="258" alt="image" src="https://github.com/user-attachments/assets/254c9f27-4064-4f03-8cf2-096c1664074a" />


