### PR TITLE
フォーム画像表示不具合

### DIFF
--- a/app/[locale]/sheets/page.tsx
+++ b/app/[locale]/sheets/page.tsx
@@ -64,15 +64,23 @@ export default function SheetsPage() {
   }
 
   function driveToImageUrl(raw: string): string | null {
-    // https://drive.google.com/open?id=FILE_ID
-    const m = raw.match(/[?&]id=([a-zA-Z0-9_-]+)/);
-    if (!m?.[1]) return null;
-    const fileId = m[1];
-    return `https://drive.google.com/thumbnail?id=${fileId}&sz=w800-h800`;
+    // 1. id=PARAMETER (e.g. https://drive.google.com/open?id=FILE_ID)
+    let m = raw.match(/[?&]id=([a-zA-Z0-9_-]+)/);
+    if (m?.[1]) {
+      return `https://drive.google.com/thumbnail?id=${m[1]}&sz=w800-h800`;
     }
 
+    // 2. /file/d/PATH_SEGMENT (e.g. https://drive.google.com/file/d/FILE_ID/view)
+    m = raw.match(/\/file\/d\/([a-zA-Z0-9_-]+)/);
+    if (m?.[1]) {
+      return `https://drive.google.com/thumbnail?id=${m[1]}&sz=w800-h800`;
+    }
+
+    return null;
+  }
+
     function isUrl(v: unknown): v is string {
-    return typeof v === "string" && v.startsWith("http");
+    return typeof v === "string" && v.trim().startsWith("http");
     }
 
 


### PR DESCRIPTION
Enhance `driveToImageUrl` to support multiple Google Drive URL formats, resolving an issue where some images from Google Forms were not displayed.

The existing code only recognized Google Drive URLs containing `id=FILE_ID`. However, Google Forms can also provide URLs in the format `https://drive.google.com/file/d/FILE_ID/view...`. This PR updates the `driveToImageUrl` function to correctly parse file IDs from both URL patterns, resolving an issue where images with the latter URL format were not displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0ab4806-d171-4cd5-b948-9685b927f9cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0ab4806-d171-4cd5-b948-9685b927f9cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

