### PR TITLE
fix: レポートページ遷移時の basePath 二重付与による 404 を修正

### DIFF
--- a/app/[locale]/components/ReportFAB.tsx
+++ b/app/[locale]/components/ReportFAB.tsx
@@ -6,8 +6,6 @@ import { useTranslation } from "react-i18next";
 import { localePath } from "../lib/localePath";
 import { isTopPagePath } from "../lib/pathUtils";
 
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
-
 /**
  * トップページの右下にのみ固定表示するレポートページへの動線ボタン。
  */
@@ -21,7 +19,7 @@ export default function ReportFAB() {
 
   return (
     <Link
-      href={`${basePath}${localePath(locale, "/report")}`}
+      href={localePath(locale, "/report")}
       className="fixed -bottom-6 -right-6 md:-bottom-10 md:-right-10 z-40 w-24 h-24 md:w-40 md:h-40 pb-6 pr-6 md:pb-10 md:pr-10 rounded-full border border-foreground/40 bg-dark-blue-primary/70 backdrop-blur-md flex flex-col items-center justify-center gap-1 text-foreground hover:bg-dark-blue-primary hover:border-foreground/70 transition-all duration-300 shadow-[0_4px_32px_rgba(0,0,50,0.5)]"
       aria-label={t("reportFAB.aria")}
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

トップページ右下の「実施報告」FAB からレポートページへ遷移すると、本番環境で `/ge2026/ge2026/ja/report/` のように `basePath` が二重になり 404 になる問題を修正しました。

## 原因

`ReportFAB` の `next/link` の `href` に `NEXT_PUBLIC_BASE_PATH`（`/ge2026`）を手動で付与していました。Next.js の `Link` は `next.config.ts` の `basePath` を自動で付与するため、ビルド後の HTML では `href="/ge2026/ge2026/ja/report/"` となり、存在しないパスへ遷移していました。

正しい URL は `/ge2026/ja/report/` です（本番で 200 を確認済み）。

## 変更内容

- `ReportFAB` の `href` を他コンポーネント（`WorkCard` 等）と同様、`localePath(locale, "/report")` のみに統一
- 不要になった `basePath` 定数を削除

## 確認方法

1. 本番ビルド（`basePath: /ge2026`）後、`out/ja/index.html` の FAB リンクが `href="/ge2026/ja/report/"` であること
2. `https://industrial-art.sd.tmu.ac.jp/ge2026/ja/` から FAB をクリックし、レポートページが表示されること
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-817db03a-19d2-416c-bf43-a7411797bebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-817db03a-19d2-416c-bf43-a7411797bebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

